### PR TITLE
Target project MethodDecoratorInterfaces referenciation

### DIFF
--- a/MethodDecorator.Fody/MethodDecorator.cs
+++ b/MethodDecorator.Fody/MethodDecorator.cs
@@ -18,7 +18,6 @@ namespace MethodDecorator.Fody {
         public void Decorate(TypeDefinition type, MethodDefinition method, CustomAttribute attribute, bool explicitMatch)
         {
 
-
             method.Body.InitLocals = true;
             
             var methodBaseTypeRef = this._referenceFinder.GetTypeReference(typeof(MethodBase));
@@ -182,7 +181,12 @@ namespace MethodDecorator.Fody {
                 processor.InsertBefore(methodBodyFirstInstruction, bypassInstructions);
 
             if (callOnEntryInstructions != null)
+            {
                 processor.InsertBefore(methodBodyFirstInstruction, callOnEntryInstructions);
+
+                if (bypassInstructions != null)
+                    processor.InsertBefore(methodBodyFirstInstruction, bypassInstructions);
+            }
 
             if (methodBodyReturnInstructions != null)
             {

--- a/MethodDecoratorInterfaces/IPartialDecorator.cs
+++ b/MethodDecoratorInterfaces/IPartialDecorator.cs
@@ -32,15 +32,15 @@ namespace MethodDecorator.Fody.Interfaces
     {
         void OnException(Exception iException);
     }
-    interface IPartialDecoratorContinuation
+    public interface IPartialDecoratorContinuation
     {
         void OnTaskContinuation(Task task);
     }
-    interface IPartialDecoratorNeedBypass
+    public interface IPartialDecoratorNeedBypass
     {
         bool NeedBypass();
     }
-    interface IPartialAlterRetval
+    public interface IPartialAlterRetval
     {
         object AlterRetval(object iRetval);
     }

--- a/MethodDecoratorInterfaces/MethodDecoratorInterfaces.csproj
+++ b/MethodDecoratorInterfaces/MethodDecoratorInterfaces.csproj
@@ -41,7 +41,6 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="IInterruptableMethodDecorator.cs" />
     <Compile Include="IMethodDecorator.cs" />
     <Compile Include="IAspectMatchingRule.cs" />
     <Compile Include="IPartialDecorator.cs" />

--- a/MethodDecoratorInterfaces/MethodDecoratorInterfaces.csproj
+++ b/MethodDecoratorInterfaces/MethodDecoratorInterfaces.csproj
@@ -41,6 +41,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IInterruptableMethodDecorator.cs" />
     <Compile Include="IMethodDecorator.cs" />
     <Compile Include="IAspectMatchingRule.cs" />
     <Compile Include="IPartialDecorator.cs" />

--- a/install.ps1
+++ b/install.ps1
@@ -66,10 +66,13 @@ function Fix-ReferencesCopyLocal($package, $project)
     {
         if ($asms -contains $reference.Name + ".dll")
         {
-            if($reference.CopyLocal -eq $true)
-            {
-                $reference.CopyLocal = $false;
-            }
+			if (-not $reference.Name -eq "MethodDecoratorInterfaces.dll")
+			{
+				if($reference.CopyLocal -eq $true)
+				{
+					$reference.CopyLocal = $false;
+				}
+			}
         }
     }
 }


### PR DESCRIPTION
The copy-local fix in the installer.ps needed an exclusion for the `MethodDecoratorInterfaces.dll`